### PR TITLE
[FIX] remove octal literal

### DIFF
--- a/js/game/event/sectionEvents.js
+++ b/js/game/event/sectionEvents.js
@@ -2757,7 +2757,7 @@ const EVENTS = {
                     (game, event) => {
                         const scene = game.scene;
                         switch (event.timelineFrame) {
-                            case 00:
+                            case 0:
                                 if (!game.noelMode) {
                                     event.flare.setAnimation('wakeup');
                                     game.playSound('wakeup');


### PR DESCRIPTION
`00` is interpreted as octal `0` so essentially it's the same value, but this form is deprecated and throws `SyntaxError` in strict mode.
Refs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal