### PR TITLE
[FIX] replace `innerHTML` with better alternatives

### DIFF
--- a/js/game/game.js
+++ b/js/game/game.js
@@ -65,7 +65,7 @@ class Game {
         }
 
         if (!SAVEOK) {
-            document.getElementById('game-container').innerHTML = 'The saving system is incompatible with your navigator, please enable cookies/localstorage';
+            document.getElementById('game-container').textContent = 'The saving system is incompatible with your navigator, please enable cookies/localstorage';
         }
 
         document.getElementById('pause-icon').onclick = () => this.togglePause();
@@ -232,7 +232,7 @@ class Game {
         }
         document.getElementById("bgm-volume-icon").onclick = e => {
             BGMMUTED = !BGMMUTED;
-            document.getElementById("bgm-volume-icon").innerHTML = BGMMUTED ? '<img src="./img/icon_volume_off.png">' : '<img src="./img/icon_volume_on.png">';
+            document.getElementById("bgm-volume-icon").firstElementChild.src = `./img/${BGMMUTED ? 'icon_volume_off' : 'icon_volume_on'}.png`;
             this.bgm.updateVolume();
         }
 
@@ -253,7 +253,7 @@ class Game {
             }
             document.getElementById("bgm-volume-icon").onclick = e => {
                 BGMMUTED = !BGMMUTED;
-                document.getElementById("bgm-volume-icon").innerHTML = BGMMUTED ? '<img src="./img/icon_volume_off.png">' : '<img src="./img/icon_volume_on.png">';
+                document.getElementById("bgm-volume-icon").firstElementChild.src = `./img/${BGMMUTED ? 'icon_volume_off' : 'icon_volume_on'}.png`;
             }
         }
     }

--- a/js/lib/inputManager.js
+++ b/js/lib/inputManager.js
@@ -138,7 +138,7 @@ const updateKeycodes = () => {
 let selectedKey = null;
 const cancelKeyChange = key => {
     const elem = document.getElementById(`key-${KEYMODE}-${key}`);
-    elem.innerHTML = KEYBOARDINPUT[key];
+    elem.textContent = KEYBOARDINPUT[key];
     elem.classList.remove('active');
     INPUTMANAGER.keyboard.enable();
     selectedKey = null;
@@ -146,7 +146,7 @@ const cancelKeyChange = key => {
 const changeKeyHandle = e => {
     const elem = document.getElementById(`key-${KEYMODE}-${selectedKey}`);
     KEYBOARDINPUT[selectedKey] = e.code;
-    elem.innerHTML = e.code;
+    elem.textContent = e.code;
     updateKeycodes();
     elem.classList.remove('active');
     INPUTMANAGER.keyboard.enable();
@@ -157,7 +157,7 @@ const changeKeyKeyboard = key => {
     selectedKey = key;
     if (KEYBOARDINPUT[selectedKey]) {
         const elem = document.getElementById(`key-${KEYMODE}-${selectedKey}`);
-        elem.innerHTML = '.';
+        elem.textContent = '.';
         elem.classList.add('active');
         INPUTMANAGER.keyboard.disable();
         document.body.onkeydown = changeKeyHandle;
@@ -167,15 +167,15 @@ const resetKeys = () => {
     if (selectedKey) cancelKeyChange(selectedKey);
     KEYCODES = {...DEFAULTKEYCODES}
     document.getElementById('gamepad-type-A').click();
-    document.getElementById('key-keyboard-left').innerHTML = 'ArrowLeft';
-    document.getElementById('key-keyboard-right').innerHTML = 'ArrowRight';
-    document.getElementById('key-keyboard-up').innerHTML = 'ArrowUp';
-    document.getElementById('key-keyboard-down').innerHTML = 'ArrowDown';
-    document.getElementById('key-keyboard-jump').innerHTML = 'KeyZ';
-    document.getElementById('key-keyboard-attack').innerHTML = 'KeyX';
-    document.getElementById('key-keyboard-item').innerHTML = 'KeyC';
-    document.getElementById('key-keyboard-l').innerHTML = 'KeyA';
-    document.getElementById('key-keyboard-r').innerHTML = 'KeyS';
+    document.getElementById('key-keyboard-left').textContent = 'ArrowLeft';
+    document.getElementById('key-keyboard-right').textContent = 'ArrowRight';
+    document.getElementById('key-keyboard-up').textContent = 'ArrowUp';
+    document.getElementById('key-keyboard-down').textContent = 'ArrowDown';
+    document.getElementById('key-keyboard-jump').textContent = 'KeyZ';
+    document.getElementById('key-keyboard-attack').textContent = 'KeyX';
+    document.getElementById('key-keyboard-item').textContent = 'KeyC';
+    document.getElementById('key-keyboard-l').textContent = 'KeyA';
+    document.getElementById('key-keyboard-r').textContent = 'KeyS';
 }
 
 let OPTIONSENABLED = false;
@@ -183,7 +183,7 @@ const toggleOptions = () => {
     const container = document.getElementById("options-container");
     const toggle = container.style.display === 'none';
     container.style.display = toggle ? 'flex' : 'none';
-    document.getElementById('options-icon').innerHTML = toggle ? '<img src="./img/icon_close.png">' : '<img src="./img/icon_settings.png">';
+    document.getElementById('options-icon').firstElementChild.src = `./img/${toggle ? 'icon_close' : 'icon_settings'}.png`;
     OPTIONSENABLED = !OPTIONSENABLED;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ const toggleInfo = () => {
     const container = document.getElementById("info-container");
     const toggle = container.style.display === 'none';
     container.style.display = toggle ? 'flex' : 'none';
-    document.getElementById('info-icon').innerHTML = toggle ? '<img src="./img/icon_close.png">' : '<img src="./img/icon_info.png">';
+    document.getElementById('info-icon').firstElementChild.src = `./img/${toggle ? 'icon_close' : 'icon_info'}.png`;
     INFOENABLED = !INFOENABLED;
 }
 
@@ -27,7 +27,7 @@ const toggleSave = () => {
     const container = document.getElementById("save-container");
     const toggle = container.style.display === 'none';
     container.style.display = toggle ? 'flex' : 'none';
-    document.getElementById('save-icon').innerHTML = toggle ? '<img src="./img/icon_close.png">' : '<img src="./img/icon_save.png">';
+    document.getElementById('save-icon').firstElementChild.src = `./img/${toggle ? 'icon_close' : 'icon_save'}.png`;
     SAVEENABLED = !SAVEENABLED;
 }
 
@@ -129,7 +129,7 @@ window.onload = () => {
     document.getElementById("se-volume").onchange = e => SEVOLUME = e.target.value;
     document.getElementById("se-volume-icon").onclick = e => {
         SEMUTED = !SEMUTED;
-        document.getElementById("se-volume-icon").innerHTML = SEMUTED ? '<img src="./img/icon_volume_off.png">' : '<img src="./img/icon_volume_on.png">';
+        document.getElementById("se-volume-icon").firstElementChild.src = `./img/${SEMUTED ? 'icon_volume_off' : 'icon_volume_on'}.png`;
     }
 
     window.onblur = () => {
@@ -148,7 +148,7 @@ window.onload = () => {
     }
     document.getElementById("bgm-volume-icon").onclick = e => {
         BGMMUTED = !BGMMUTED;
-        document.getElementById("bgm-volume-icon").innerHTML = BGMMUTED ? '<img src="./img/icon_volume_off.png">' : '<img src="./img/icon_volume_on.png">';
+        document.getElementById("bgm-volume-icon").firstElementChild.src = `./img/${BGMMUTED ? 'icon_volume_off' : 'icon_volume_on'}.png`;
     }
 
     if (typeof __TAURI__ !== 'undefined') {


### PR DESCRIPTION
Using `innerHTML` is usually never a good thing if we can use `textContent` or alternate DOM elements directly.
In particular, this should fix menu buttons "blinking" in some scenarios.