### PR TITLE
[FIX] fix freeze using clock when entering suityan boss room

### DIFF
--- a/js/game/actor/suisei.js
+++ b/js/game/actor/suisei.js
@@ -13,6 +13,9 @@ class Suisei extends Actor {
 
     healthBar = 0;
 
+    animation = 'stand';
+    animationFrame = 0;
+
     constructor(pos, maxHealth, axe) {
         super(pos);
         this.maxHealth = maxHealth;


### PR DESCRIPTION
`suisei.draw()` can be called before `suisei.introPhase(game)` and `suisei.setAnimation('stand')`, causing `suisei.animation` and `suisei.animationFrame` to be `undefined`.
Defining initial values should fix this.