### PR TITLE
[FIX] improve performance of stage loading

### DIFF
--- a/js/game/game.js
+++ b/js/game/game.js
@@ -32,7 +32,7 @@ class Game {
         // Assets
         this.assets = assets;
 
-        // JSON data
+        // parsed game file data
         this.data = data;
 
         // Controller
@@ -83,7 +83,7 @@ class Game {
         // if (urlParams.has('stage')) this.currentStage = parseInt(urlParams.get('stage')) - 1;
 
         // Init stage selection
-        this.scene = new Scene(this, JSON.parse(this.data).game.stages[this.currentStage]);
+        this.scene = new Scene(this, this.data.game.stages[this.currentStage]);
 
         if (!localStorage.getItem('nuinui-save-item-fire')) localStorage.setItem('nuinui-save-item-fire', true);
         this.updateItems();

--- a/js/game/stageSelect.js
+++ b/js/game/stageSelect.js
@@ -23,7 +23,7 @@ class StageSelect {
 
         if (this.frameCount === 180) {
             game.currentStage = this.selectedStage;
-            game.scene = new Scene(game, JSON.parse(game.data).game.stages[this.selectedStage]);
+            game.scene = new Scene(game, game.data.game.stages[this.selectedStage]);
         }
 
         this.frameCount++;

--- a/js/main.js
+++ b/js/main.js
@@ -116,13 +116,13 @@ const debugSave = () => {
 }
 // debugSave();
 
-window.onload = () => {
+window.addEventListener('load', () => {
     INPUTMANAGER = new InputManager();
     // Game
     fetch("save.json").then(res => res.json()).then(res => {
         console.log("game file loaded", res);
         const game = new Game(new Assets(), Object.freeze(res));
-        game.assets.load()
+        game.assets.load();
         game.start();
     });
 
@@ -168,4 +168,4 @@ window.onload = () => {
             document.body.style.cursor = "none";
         }, 1000);
     }
-}
+}, { once: true });

--- a/js/main.js
+++ b/js/main.js
@@ -121,8 +121,9 @@ window.onload = () => {
     // Game
     fetch("save.json").then(res => res.json()).then(res => {
         console.log("game file loaded", res);
-        const game = new Game(new Assets(), JSON.stringify(res));
-        game.assets.load().then(game.start());
+        const game = new Game(new Assets(), Object.freeze(res));
+        game.assets.load()
+        game.start();
     });
 
     // Sound options


### PR DESCRIPTION
Storing `save.json` as JS object would speed up loading because we don't have to deserialize 0.6 MB json string every time a stage is loaded.