### PR TITLE
[FIX] fix issues on stage selection

### DIFF
--- a/js/game/game.js
+++ b/js/game/game.js
@@ -181,6 +181,10 @@ class Game {
         }
     }
 
+    resetState = () => {
+        this.cpuKeys = {};
+    }
+
     draw = () => {
         this.animation = requestAnimationFrame(this.draw);
         if(!this.drawBuffer && (!this.fpsSkipMode || this.scene.frameCount % 2)) {

--- a/js/game/stageSelect.js
+++ b/js/game/stageSelect.js
@@ -34,11 +34,8 @@ class StageSelect {
             const cx = game[`ctx${i}`];
             cx.save();
             switch (i) {
-                case 0:
-                    cx.fillStyle = "#000";
-                    cx.fillRect(0, 0, game.width, game.height);
-                    break;
                 case 3:
+                    cx.fillStyle = "#000";
                     cx.clearRect(0, 0, game.width, game.height);
                     cx.translate(game.width / 2 - 112, 0);
                     for (let i = 0; i < 5; i++) {
@@ -58,6 +55,11 @@ class StageSelect {
                     cx.globalAlpha = this.transitionAlpha;
                     cx.fillRect(0, 0, game.width, game.height);
                     break;
+                default:
+                    if (this.frameCount === 0) {
+                        cx.fillStyle = "#000";
+                        cx.fillRect(0, 0, game.width, game.height);
+                    }
             }
             cx.restore();
         }

--- a/js/game/stageSelect.js
+++ b/js/game/stageSelect.js
@@ -7,13 +7,17 @@ class StageSelect {
         this.selectedStage = selectedStage;
 
         game.resetCanvas();
-        
+        game.resetState();
+
         // Save
         for (let i = 0; i < 5; i++) document.getElementById(`save-stage-${i+1}`).onclick = e => null;
     }
 
     update = game => {
-        if (!this.frameCount) game.stopBGM();
+        if (!this.frameCount) {
+            game.stopBGM();
+            game.cpuKeys = {};
+        }
 
         if (this.frameCount < 30) this.transitionAlpha = 1 - this.frameCount / 30;
         else if (this.frameCount < 150) this.transitionAlpha = 0;


### PR DESCRIPTION
This should fix the following issues on stage selection:
- ![stageSelect](https://user-images.githubusercontent.com/74449973/226669774-77bd4249-8435-4cc1-b2ab-a5b192a8b07c.png)
(AFAICT nothing is drawn on 0th layer during this sequence, so we can fill it only on first frame)

- ![stageSelectCpu](https://user-images.githubusercontent.com/74449973/226681361-ce3efe53-ba81-4f8e-8cd0-fa1e2212dc42.png)

I couldn't reproduce crash so far.